### PR TITLE
Update to the latest clojure and core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/brunoV/throttler"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/core.async "0.1.278.0-76b25b-alpha"]]
-  :profiles {:dev {:dependencies [[midje "1.5.1"]
-                                  [criterium "0.4.3"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/core.async "0.4.490"]]
+  :profiles {:dev {:dependencies [[midje "1.9.8"]
+                                  [criterium "0.4.5"]]
                    :plugins [[lein-midje "3.1.1"]]}})

--- a/test/throttler/t_core.clj
+++ b/test/throttler/t_core.clj
@@ -10,7 +10,7 @@
 
     (fact "It returns something"
       (throttle-fn + 1 :second) => truthy
-      (throttle-fn + 1 :second 9) => truthy)
+      (throttle-fn + 1 :second 9) => truthy
 
       (fact "It acts like the original function"
         (+? 1 1) => (+ 1 1)
@@ -27,7 +27,7 @@
         (throttle-fn + :foo :hour)      => (throws IllegalArgumentException)
         (throttle-fn +  0   :hour)      => (throws IllegalArgumentException)
         (throttle-fn +  1   :hour :foo) => (throws IllegalArgumentException)
-        (throttle-fn +  1   :hour -1)   => (throws IllegalArgumentException))))
+        (throttle-fn +  1   :hour -1)   => (throws IllegalArgumentException)))))
 
 (facts "about throttle-chan"
   (let [in (chan 1)


### PR DESCRIPTION
My editor autoformatted a bunch of lines and I cleaned whatever kibit/eastwood threw at me, if it's annoying I can drop those changes.

The only real differences are the versions in `project.clj` and setting the default bucket size to 1. Which I had to do to appease `core.async`. I think this is identical to the old behavior but some change in the history of `dropping-buffer` caused it to discard all input so attempting to retrieving from it will wait forever.