### PR TITLE
Accurate rate calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Some of its key features:
 
 * Control both average rate and burstiness.
 * Accurate over a large range of rates.
-* Lightweight. Based on [core.async][core-async], does not rely on
+* Lightweight. Based on
+  [java.util.concurrent.ScheduledExecutorService][scheduler] instead of relying on
   `Thread/sleep` so each throttler does not require a dedicated thread. Use as
   many as you want.
 * Throttle a single function/channel or a group under the same rate
@@ -148,7 +149,7 @@ Here's the result of running some [Criterium][crit] benchmarks on channels
 throttled at different rates.
 
 ```
-Goal rate              Observed rate (mean)  Lower quantile (2.5%)  Upper quantile (95.5%)
+Goal rate              Observed rate (mean)  Lower quantile (2.5%)  Upper quantile (97.5%)
 ---------------------  --------------------  ---------------------  ---------------------
       0.1  msg/s           0.1010 msgs/s          0.1008 msgs/s          0.1016 msgs/s
       1    msg/s           1.071  msgs/s          1.056  msgs/s          1.126  msgs/s
@@ -174,7 +175,7 @@ Browse the [API Docs][docs] or check out the [blog post][blog] for more.
 [token]:      http://en.wikipedia.org/wiki/Token_bucket
 [crit]:       https://github.com/hugoduncan/criterium
 [docs]:       https://brunov.github.io/throttler
-[core-async]: https://github.com/clojure/core.async
+[scheduler]:  https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html
 [blog]:       http://brunov.org/clojure/2014/05/14/throttler/
 
 ## License

--- a/src/throttler/core.clj
+++ b/src/throttler/core.clj
@@ -1,18 +1,12 @@
 (ns throttler.core
-  (:require [clojure.core.async :refer [chan <!! >!! >! <! timeout go close! dropping-buffer]]))
+  (:require [clojure.core.async :refer [chan <!! >!! >! <! go close! dropping-buffer]])
+  (:import (java.util.concurrent Executors TimeUnit ScheduledExecutorService)))
 
-;; To keep the throttler precise even for high frequencies, we set up a
-;; minimum sleep time. In my tests I found that below 10 ms the actual
-;; sleep time has an error of more than 10%, so we stay above that.
-(def ^{:no-doc true} min-sleep-time 10)
-
-(defn- round [n] (Math/round (double n)))
-
-(def ^{:no-doc true} unit->ms
-  {:microsecond 0.001 :millisecond 1
-   :second 1000 :minute 60000
-   :hour 3600000 :day 86400000
-   :month 2678400000})
+(def ^{:no-doc true} unit->ns
+  {:nanosecond 1 :microsecond 1.0E3 :millisecond 1.0E6
+   :second 1.0E9 :minute 6.0E10
+   :hour 3.6E12 :day 8.64E13
+   :month 2.6784E15})
 
 (defmacro pipe
   "Pipes an element from the from channel and supplies it to the to
@@ -24,34 +18,28 @@
        (close! ~to)
        (>! ~to v#))))
 
-(defn- chan-throttler* [rate-ms bucket-size]
-  (let [sleep-time (round (max (/ rate-ms) min-sleep-time))
-        token-value (round (* sleep-time rate-ms))   ; how many messages to pipe per token
-        bucket (chan (dropping-buffer bucket-size))] ; we model the bucket with a buffered channel
+(def scheduler (Executors/newSingleThreadScheduledExecutor))
 
-    ;; The bucket filler thread. Puts a token in the bucket every
-    ;; sleep-time seconds. If the bucket is full the token is dropped
-    ;; since the bucket channel uses a dropping buffer.
-    (go
-     (while (>! bucket :token)
-       (<! (timeout (int sleep-time)))))
+(defn- chan-throttler* [rate-ns bucket-size]
+  (let [sleep-time (Math/round (double (/ rate-ns)))
+        ; we model the bucket with a buffered channel
+        bucket (chan (dropping-buffer bucket-size))
+        ;; The bucket filler thread. Puts a token in the bucket every
+        ;; sleep-time seconds. If the bucket is full the token is dropped
+        ;; since the bucket channel uses a dropping buffer.
+        task (.scheduleAtFixedRate ^ScheduledExecutorService scheduler
+               (fn [] (>!! bucket :token)) sleep-time sleep-time TimeUnit/NANOSECONDS)]
 
     ;; The piping thread. Takes a token from the bucket (blocking until
     ;; one is ready if the bucket is empty), and forwards token-value
     ;; messages from the source channel to the output channel.
-
-    ;; For high frequencies, we leave sleep-time fixed to
-    ;; min-sleep-time, and we increase token-value, the number of
-    ;; messages to pipe per token. For low frequencies, the token-value
-    ;; is 1 and we adjust sleep-time to obtain the desired rate.
-
     (fn [c]
       (let [c' (chan)] ; the throttled chan
         (go
           (while (<! bucket) ; block for a token
-            (dotimes [_ token-value]
-              (when-not (pipe c c')
-                (close! bucket)))))
+            (when-not (pipe c c')
+                (close! bucket)
+                (.cancel task true))))
         c'))))
 
 (defn chan-throttler
@@ -71,9 +59,9 @@
   ([rate unit]
    (chan-throttler rate unit 1))
   ([rate unit bucket-size]
-   (when (nil? (unit->ms unit))
+   (when (nil? (unit->ns unit))
      (throw (IllegalArgumentException.
-             (str "Invalid unit. Available units are: " (keys unit->ms)))))
+             (str "Invalid unit. Available units are: " (keys unit->ns)))))
 
    (when-not (and (number? rate) (pos? rate))
      (throw (IllegalArgumentException. "rate should be a positive number")))
@@ -81,8 +69,8 @@
    (when (or (not (integer? bucket-size)) (neg? bucket-size))
      (throw (IllegalArgumentException. "bucket-size should be a non-negative integer")))
 
-   (let [rate-ms (/ rate (unit->ms unit))]
-     (chan-throttler* rate-ms bucket-size))))
+   (let [rate-ns (/ rate (unit->ns unit))]
+     (chan-throttler* rate-ns bucket-size))))
 
 (defn throttle-chan
      "Takes a write channel, a goal rate and a unit and returns a read


### PR DESCRIPTION
Per #11, some rates aren't possible due to rounding and we can't specify sub-[10ms](https://github.com/clojure/core.async/blob/162d4e62aeb41b50602bb808657f090e0504391c/src/main/clojure/clojure/core/async/impl/timers.clj#L23) in core.async/timeout because of how it [buckets requests](http://danboykis.com/posts/core-async-timeout-channels/). Per @dball's advice on the clojurians Slack I took a swing at replacing timeout with java.util.concurrent.ScheduledExecutorService. It fairly accurately represents the lower values from #11 correctly but I'm not confident it's the best solution. It breaks one of this projects goals of not needing an additional thread and I'd really rather @brunoV signed off on that.

I'd love to have the script that was used to generate the table in the README for comparison...